### PR TITLE
Reorganize MQTT topics and add documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "system-mqtt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "argh",
  "battery",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["James Carl"]
 version = "0.2.0"
 edition = "2018"
 license = "MIT"
+readme = "README.md"
 description = "Broadcasts system statistics to an mqtt server of your choice. Ideal for home assistant!"
 repository = "https://github.com/IamTheCarl/system-mqtt"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "system-mqtt"
 authors = ["James Carl"]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Want more statistics to be reported? I'm fine with that. Just make a pull reques
 
 If for some reason your feature just can't be fit within those requirement, make the pull request anyway and we'll talk about it. I'm sure we can find a compromise.
 
+# Dependencies
+
+* Building `system-mqtt` requires the Rust toolchain including the `cargo` package manager. Default repositories may be out of date and fail to build, so it is recommended to install Rust using the installer at [Rustup](https://rustup.rs/). Remove any existing instances of `rustc` on your system, and install a fresh copy of Rust using the instructions on Rustup.rs.
+* The Cargo helper command [cargo-deb](https://crates.io/crates/cargo-deb) is required to allow `cargo` to build a .deb package. Once Rust is installed, add `cargo-deb` with the command `cargo install cargo-deb`.
+* `libdbus-1-dev` is required, but not installed by default on many Debian systems. `sudo apt install libdbus-1-dev` will install from the Debian or Ubuntu repositories.
+* `libdbus-1-3` or similar is required, but is installed by default on most Debian and Ubuntu systems.
+
 # Installation
 
 I brewed this up in less than a day and have less than an hour of runtime with it, so I don't feel ready to publish proper releases or a fancy pre-packaged installer. This means you'll be installing it from source.
@@ -35,20 +42,19 @@ Step 1: [Setup MQTT with Home Assistant](https://www.home-assistant.io/integrati
 
 Step 2: Clone this repository.
 
-Step 3: Make sure you have [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) installed.
+Step 3: Verify all dependencies are installed.
 
-Step 4: Install [cargo deb](https://crates.io/crates/cargo-deb).
+Step 4: Run the command `cargo deb --install` from the cloned directory.
 
-Step 5: Run the command `cargo deb --install`.
-
-At this point you've installed system-mqtt as a debian package that can easily be removed.
+At this point you've installed `system-mqtt` as a debian package that can easily be removed. It will automatically be registered with systemd, but may require a manual start with `systemctl start system-mqtt`.
 
 At this point the daemon is installed, but won't run if the mqtt broker is not running on the local system. You'll need to edit the configuration to let it know about the mqtt broker and its credentials.
 
 # Configuration
 
-The configuration file lives under `/etc/system-mqtt.yaml`.
-If it does not when you install system-mqtt, it will be created and populated with default arguments.
+The configuration file lives at `/etc/system-mqtt.yaml`.
+
+If it does not appear when you first install system-mqtt, it will be created and populated when `system-mqtt` is run with default arguments.
 
 Here is the default config with comments added explaining the configuration options:
 ```yaml
@@ -77,4 +83,5 @@ drives:
 ```
 
 Once you have adjusted the configuration as needed, run `systemctl reload system-mqtt` to restart the service with the new configuration.
+
 Run `systemctl status system-mqtt` after to verify the configuration loaded and the daemon is running correctly.

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,13 +212,13 @@ async fn application_trampoline(config: &Config) -> Result<()> {
         let message = serde_json::ser::to_string(&TopicConfig {
             name: format!("{}-{}", hostname, topic_name),
             device_class: device_class.map(str::to_string),
-            state_topic: format!("/{}/{}", hostname, topic_name),
+            state_topic: format!("system-mqtt/{}/{}", hostname, topic_name),
             unit_of_measurement: unit_of_measurement.map(str::to_string),
         })?;
         let mut publish = Publish::new(
             format!(
-                "homeassistant/{}/{}/{}/config",
-                topic_class, topic_name, hostname
+                "homeassistant/{}/system-mqtt/{}/{}/config",
+                topic_class, hostname, topic_name
             ),
             message.into(),
         );
@@ -233,7 +233,7 @@ async fn application_trampoline(config: &Config) -> Result<()> {
         topic_name: &str,
         value: String,
     ) -> Result<()> {
-        let mut publish = Publish::new(format!("/{}/{}", hostname, topic_name), value.into());
+        let mut publish = Publish::new(format!("system-mqtt/{}/{}", hostname, topic_name), value.into());
         publish.set_retain(false);
         client.publish(&publish).await?;
 
@@ -279,7 +279,7 @@ async fn application_trampoline(config: &Config) -> Result<()> {
 
     client
         .publish(
-            &Publish::new(format!("{}/availability", hostname), "online".into()).set_retain(true),
+            &Publish::new(format!("system-mqtt/{}/availability", hostname), "online".into()).set_retain(true),
         )
         .await?;
 
@@ -366,7 +366,7 @@ async fn application_trampoline(config: &Config) -> Result<()> {
 
     client
         .publish(
-            &Publish::new(format!("{}/availability", hostname), "offline".into()).set_retain(true),
+            &Publish::new(format!("system-mqtt/{}/availability", hostname), "offline".into()).set_retain(true),
         )
         .await?;
 


### PR DESCRIPTION
- Add documentation details on dependencies, particularly the few I got hung up on.
- Reorganize the MQTT topics into more logical buckets to allow for multiple servers more cleanly, and to keep all of the topics associated with one server in one place. This is what the new topic structure looks like:

<img width="391" alt="image" src="https://user-images.githubusercontent.com/49047/165667754-409dd5c6-58e4-49d1-a08e-dfca8c8bdae0.png">

- Add icon option to the autoconfiguration, with a default icon hardcoded for each sensor. In the future this would probably be best added as a configuration option with a default in the yaml file.
- Reorganized the topic registration code a bit for a more logical flow by grouping the sensors together. Cargo fmt insists on spreading these calls out which makes for a lot of lines, up to you on whether we pull them back onto one line for quicker editing.

All in all, I'm a novice developer in all regards, and extremely novice in rust, so all criticism or suggestions are welcome. Thanks for making a helpful tool!